### PR TITLE
Fix dedicated client not responding after a while

### DIFF
--- a/Fika.Dedicated/FikaDedicatedPlugin.cs
+++ b/Fika.Dedicated/FikaDedicatedPlugin.cs
@@ -119,11 +119,11 @@ namespace Fika.Dedicated
              * but it works for now and I was getting a CTD with other method
             */
 
+            StopCoroutine(setDedicatedStatusRoutine);
+
             Task.Run(async () =>
             {
-                StopCoroutine(setDedicatedStatusRoutine);
                 SetDedicatedStatusRequest setDedicatedStatusRequest = new(RequestHandler.SessionId, "inraid");
-
                 await FikaRequestHandler.SetDedicatedStatus(setDedicatedStatusRequest);
             });
 
@@ -270,10 +270,9 @@ namespace Fika.Dedicated
         {
             while (true)
             {
-                SetDedicatedStatusRequest setDedicatedStatusRequest = new(RequestHandler.SessionId, "ready");
-
                 Task.Run(async () =>
                 {
+                    SetDedicatedStatusRequest setDedicatedStatusRequest = new(RequestHandler.SessionId, "ready");
                     await FikaRequestHandler.SetDedicatedStatus(setDedicatedStatusRequest);
                 });
 


### PR DESCRIPTION
I believe the issue is a timeout caused by the fact that we are keeping the Websocket connection open without activity for long times. This adds a keep alive (ping pong) feature to keep the connection alive. 

Also, fixed a bug where the dedicated status would continue to send during raid and added a stronger re connection process.

Works in combination with https://github.com/project-fika/Fika-Server/pull/69