### PR TITLE
Set CurrentPlayer on freecam script on dedicated client raid start

### DIFF
--- a/Fika.Dedicated/Classes/DedicatedRaidController.cs
+++ b/Fika.Dedicated/Classes/DedicatedRaidController.cs
@@ -78,6 +78,7 @@ namespace Fika.Dedicated.Classes
 						{
 							freeCameraController.ToggleCamera();
 						}
+						freeCam.SetCurrentPlayer(targetPlayer);
 						freeCam.AttachDedicated(targetPlayer);
 						return;
                     }


### PR DESCRIPTION
FreeCam script will attempt to swap to shoulder cam on next available player on dedicated client raid start if `allowSpectateFreeCam` is disabled and `CurrentPlayer` is not set, so to preserve the dedicated cam overhead position we tell the script we're already watching a player.