### PR TITLE
Disable bot sleeping by default (Add option to re-enable it)

### DIFF
--- a/Fika.Dedicated/FikaDedicatedPlugin.cs
+++ b/Fika.Dedicated/FikaDedicatedPlugin.cs
@@ -51,6 +51,7 @@ namespace Fika.Dedicated
 
 		public static ConfigEntry<int> UpdateRate { get; private set; }
 		public static ConfigEntry<int> RAMCleanInterval { get; private set; }
+		public static ConfigEntry<bool> ShouldBotsSleep { get; private set; }
 
 		private void Awake()
 		{
@@ -96,6 +97,11 @@ namespace Fika.Dedicated
 			new LevelSettings_ApplySettings_Patch().Enable();
 			new LevelSettings_ApplyTreeWindSettings_Patch().Enable();
 
+			if (!ShouldBotsSleep.Value)
+			{
+				new BotStandBy_Update_Patch().Enable();
+			}
+
 			DestroyGraphicsAutoloader.EnableDestroyGraphicsPatches();
 
 			//InvokeRepeating("ClearRenderables", 1f, 1f);
@@ -126,6 +132,9 @@ namespace Fika.Dedicated
 			RAMCleanInterval = Config.Bind("Dedicated", "RAM Clean Interval", 5,
 				new ConfigDescription("How often in minutes the RAM cleaner should run",
 				new AcceptableValueRange<int>(1, 30)));
+
+			ShouldBotsSleep = Config.Bind("Dedicated", "Bot sleeping", false,
+				new ConfigDescription("Should the dedicated host allow bots to sleep? (BSG bot sleeping logic)"));
 		}
 
 		protected void Update()

--- a/Fika.Dedicated/Patches/BotStandBy_Update_Patch.cs
+++ b/Fika.Dedicated/Patches/BotStandBy_Update_Patch.cs
@@ -3,7 +3,9 @@ using System.Reflection;
 
 namespace Fika.Dedicated.Patches
 {
-	// The purpose of this patch is to disable bot sleeping on the dedicated host.
+	/// <summary>
+	/// The purpose of this patch is to disable bot sleeping on the dedicated host
+	/// </summary>
 	internal class BotStandBy_Update_Patch : ModulePatch
 	{
 		protected override MethodBase GetTargetMethod()

--- a/Fika.Dedicated/Patches/BotStandBy_Update_Patch.cs
+++ b/Fika.Dedicated/Patches/BotStandBy_Update_Patch.cs
@@ -1,0 +1,20 @@
+﻿using SPT.Reflection.Patching;
+using System.Reflection;
+
+namespace Fika.Dedicated.Patches
+{
+	// The purpose of this patch is to disable bot sleeping on the dedicated host.
+	internal class BotStandBy_Update_Patch : ModulePatch
+	{
+		protected override MethodBase GetTargetMethod()
+		{
+			return typeof(BotStandBy).GetMethod(nameof(BotStandBy.Update));
+		}
+
+		[PatchPrefix]
+		public static bool Prefix()
+		{
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Disables bot sleeping by default as well as adds a configuration option for re-enabling this behavior.