### PR TITLE
Add AmandsSense to invalidPluginList

### DIFF
--- a/Fika.Dedicated/FikaDedicatedPlugin.cs
+++ b/Fika.Dedicated/FikaDedicatedPlugin.cs
@@ -240,6 +240,7 @@ namespace Fika.Dedicated
 			List<string> invalidPluginList =
 			[
 				"com.Amanda.Graphics",
+				"com.Amanda.Sense",
 				"VIP.TommySoucy.MoreCheckmarks",
 				"com.kmyuhkyuk.EFTApi",
 				"com.mpstark.DynamicMaps",


### PR DESCRIPTION
I imagine not too many people are still using AmandsSense as there's only been beta releases for the last few versions of SPT but it stops the loading of the `GameUIScene` (hangs after `Scene woods_Culling is fully loaded.`, for example).