### PR TITLE
Add StatTrack and SPTLeaderboard to invalid plugins

### DIFF
--- a/Fika.Headless/FikaHeadlessPlugin.cs
+++ b/Fika.Headless/FikaHeadlessPlugin.cs
@@ -400,7 +400,9 @@ public class FikaHeadlessPlugin : BaseUnityPlugin
             "IhanaMies.LootValue",
             "com.cactuspie.ramcleanerinterval",
             "com.TYR.DeClutter",
-            "SPTVRAMCleaner.UniqueGUID"
+            "SPTVRAMCleaner.UniqueGUID",
+            "harmonyzt.sptleaderboard",
+            "com.acidphantasm.stattrack"
         ];
         PluginInfo[] pluginInfos = [.. Chainloader.PluginInfos.Values];
         List<string> unsupportedMods = [];


### PR DESCRIPTION
at the request of harmony & Acid to reduce server calls, plus these plugins may cause issues anyway